### PR TITLE
fgkaslr: reconstruct kallsyms

### DIFF
--- a/arch/x86/boot/compressed/Makefile
+++ b/arch/x86/boot/compressed/Makefile
@@ -117,7 +117,7 @@ quiet_cmd_check-and-link-vmlinux = LD      $@
 $(obj)/vmlinux: $(vmlinux-objs-y) FORCE
 	$(call if_changed,check-and-link-vmlinux)
 
-OBJCOPYFLAGS_vmlinux.bin :=  -R .comment -S
+OBJCOPYFLAGS_vmlinux.bin :=  -R .comment -S --keep-symbols=$(obj)/vmlinux.symbols
 $(obj)/vmlinux.bin: vmlinux FORCE
 	$(call if_changed,objcopy)
 

--- a/arch/x86/boot/compressed/vmlinux.symbols
+++ b/arch/x86/boot/compressed/vmlinux.symbols
@@ -1,0 +1,9 @@
+kallsyms_offsets
+kallsyms_addresses
+kallsyms_num_syms
+kallsyms_relative_base
+kallsyms_names
+kallsyms_token_table
+kallsyms_token_index
+kallsyms_markers
+

--- a/arch/x86/include/asm/boot.h
+++ b/arch/x86/include/asm/boot.h
@@ -27,7 +27,7 @@
 #ifdef CONFIG_KERNEL_BZIP2
 # define BOOT_HEAP_SIZE		0x400000
 #else /* !CONFIG_KERNEL_BZIP2 */
-# define BOOT_HEAP_SIZE		 0x100000
+# define BOOT_HEAP_SIZE		 0x2000000
 #endif
 
 #ifdef CONFIG_X86_64

--- a/drivers/misc/test_module/test_module.c
+++ b/drivers/misc/test_module/test_module.c
@@ -4,6 +4,7 @@
 
 #include <linux/init.h>
 #include <linux/module.h>
+#include <linux/kallsyms.h>
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/slab.h>
@@ -148,6 +149,26 @@ static void __attribute__((optimize("O0"))) test_module_wq_func(struct work_stru
 	return;
 }
 
+static void test_module_test_kallsyms(void)
+{
+	unsigned long expected, result;
+	char buffer[128];
+	int bytes;
+
+	expected = (unsigned long) test_module_do_work;
+
+	result = kallsyms_lookup_name("test_module_do_work");
+
+	pr_info("testing kallsyms_lookup_name...");
+	if (expected != result)
+		pr_info("Failed kallsyms_lookup_name: expected %lx, got %lx", expected, result);
+
+	pr_info("testing sprint_symbol...");
+	bytes = sprint_symbol(buffer, expected);
+	if (bytes != strlen("test_module_do_work") && !strcmp("test_module_do_work", buffer))
+		pr_info("Failed sprint_symbol test: %s\n", buffer);
+}
+
 static int __init test_module_init(void)
 {
 	int ret;
@@ -162,6 +183,8 @@ static int __init test_module_init(void)
 	 * that was randomized.
 	 */
 	test_module_do_work();
+
+	test_module_test_kallsyms();
 
 	/*
 	 * here we are adding the address of a function that has


### PR DESCRIPTION
kallsyms is generated at build time and must contain a sorted
array of offsets as well as a table of indices into a compressed
token table. We don't need to regenerate the tokens, but we will
need to resort both the offsets and the names tables after we've
randomized everything. In order to do this, the boot kernel needs
to get access to the address of these tables so it can rewrite
them in place.  This patch adds an option to retain a few symbols
during the objcopy so that we can read their location in the boot
kernel. We use the existing kernel sort algorithm to resort
the offsets and names after randomization but before relocation.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>